### PR TITLE
Fix PlexPy start-up when using systemd unit ; remove port selection (fix #16)

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -50,14 +50,17 @@ case "$1" in
             SHOWTAB="0"
         fi
 
+        # Migration
+        if omv_config_exists "${SERVICE_XPATH}/pyport"; then
+            omv_config_del_key "${SERVICE_XPATH}/pyport"
+        fi
+        
         if omv_config_exists "${SERVICE_XPATH}/pyport"; then
             PYENABLE="$(omv_config_get "${SERVICE_XPATH}/pyenable")"
             PYRUN="$(omv_config_get "${SERVICE_XPATH}/pyrun")"
-            PYPORT="$(omv_config_get "${SERVICE_XPATH}/pyport")"
         else
             PYENABLE="0"
             PYRUN="0"
-            PYPORT="8182"
         fi
 
         omv_config_delete "${SERVICE_XPATH}"
@@ -70,7 +73,6 @@ case "$1" in
         omv_config_add_key "${SERVICE_XPATH}" "showtab" "${SHOWTAB}"
         omv_config_add_key "${SERVICE_XPATH}" "pyenable" "${PYENABLE}"
         omv_config_add_key "${SERVICE_XPATH}" "pyrun" "${PYRUN}"
-        omv_config_add_key "${SERVICE_XPATH}" "pyport" "${PYPORT}"
 
         dpkg-trigger update-fixperms
         dpkg-trigger update-locale

--- a/debian/postinst
+++ b/debian/postinst
@@ -50,12 +50,7 @@ case "$1" in
             SHOWTAB="0"
         fi
 
-        # Migration
-        if omv_config_exists "${SERVICE_XPATH}/pyport"; then
-            omv_config_delete "${SERVICE_XPATH}/pyport"
-        fi
-        
-        if omv_config_exists "${SERVICE_XPATH}/pyport"; then
+        if omv_config_exists "${SERVICE_XPATH}/pyenable"; then
             PYENABLE="$(omv_config_get "${SERVICE_XPATH}/pyenable")"
             PYRUN="$(omv_config_get "${SERVICE_XPATH}/pyrun")"
         else

--- a/debian/postinst
+++ b/debian/postinst
@@ -52,7 +52,7 @@ case "$1" in
 
         # Migration
         if omv_config_exists "${SERVICE_XPATH}/pyport"; then
-            omv_config_del_key "${SERVICE_XPATH}/pyport"
+            omv_config_delete "${SERVICE_XPATH}/pyport"
         fi
         
         if omv_config_exists "${SERVICE_XPATH}/pyport"; then

--- a/usr/share/openmediavault/datamodels/conf.service.plexmediaserver.json
+++ b/usr/share/openmediavault/datamodels/conf.service.plexmediaserver.json
@@ -30,12 +30,6 @@
 		"showtab": {
 			"type": "boolean",
 			"default": false
-		},
-		"pyport": {
-			"type": "integer",
-			"minimum": 1024,
-			"maximum": 65535,
-			"default": 8182
 		}
 	}
 }

--- a/usr/share/openmediavault/datamodels/rpc.plexmediaserver.json
+++ b/usr/share/openmediavault/datamodels/rpc.plexmediaserver.json
@@ -23,12 +23,6 @@
 			"showtab": {
 				"type": "boolean",
 				"required": true
-			},
-			"pyport": {
-				"type": "integer",
-				"minimum": 1024,
-				"maximum": 65535,
-				"required": false
 			}
 		}
 	}

--- a/usr/share/openmediavault/mkconf/plexmediaserver
+++ b/usr/share/openmediavault/mkconf/plexmediaserver
@@ -28,6 +28,12 @@ if [ "$(omv_config_get "//services/plexmediaserver/pyenable")" = "1" ]; then
         chown -R plexpy:nogroup /opt/plexpy
         cp -f /opt/plexpy/init-scripts/init.systemd /lib/systemd/system/plexpy.service
         systemctl daemon-reload
+    else
+        # Migration
+        if [ $(stat -c "%U" /opt/plexpy/) != "plexpy" ]; then
+            adduser --system --no-create-home plexpy
+            chown -R plexpy:nogroup /opt/plexpy
+        fi
     fi
 
     # Configure

--- a/usr/share/openmediavault/mkconf/plexmediaserver
+++ b/usr/share/openmediavault/mkconf/plexmediaserver
@@ -24,43 +24,14 @@ set -e
 if [ "$(omv_config_get "//services/plexmediaserver/pyenable")" = "1" ]; then
     if [ ! -d /opt/plexpy ]; then
         git clone https://github.com/JonnyWong16/plexpy.git /opt/plexpy
-        chmod +x /opt/plexpy/init-scripts/init.systemd
+        adduser --system --no-create-home plexpy
+        chown -R plexpy:nogroup /opt/plexpy
         cp -f /opt/plexpy/init-scripts/init.systemd /lib/systemd/system/plexpy.service
         systemctl daemon-reload
-        chown -R plex:nogroup /opt/plexpy
     fi
 
     # Configure
     if [ "$(omv_config_get "//services/plexmediaserver/pyrun")" = "1" ]; then
-        # Create defaults
-        HP_PORT="$(omv_config_get "//services/plexmediaserver/pyport")"
-        cat <<EOF > /etc/default/plexpy
-## The defaults
-# Run as username
-HP_USER=plex
-
-# Path to app HP_HOME=path_to_app_PlexPy.py
-HP_HOME=/opt/plexpy
-
-# Data directory where plexpy.db, cache and logs are stored
-HP_DATA=/opt/plexpy
-
-# Path to store PID file
-HP_PIDFILE=/var/run/plexpy/plexpy.pid
-
-# Path to python bin
-PYTHON_BIN=/usr/bin/python
-
-# Extra daemon option like: HP_OPTS=" --config=/opt/plexpy/config.ini"
-HP_OPTS=" --config=/opt/plexpy/config.ini"
-
-# Extra start-stop-daemon option like START_OPTS=" --group=users"
-SSD_OPTS=
-
-# Hardcoded port to run on, overrides config.ini settings
-HP_PORT="${HP_PORT} "
-
-EOF
         systemctl enable plexpy.service || true
         systemctl restart plexpy.service || true
     else
@@ -71,10 +42,10 @@ else
     if [ -d /opt/plexpy ]; then
         systemctl disable plexpy.service || true
         systemctl stop plexpy.service || true
-        rm -f /etc/default/plexpy
-        rm -rf /opt/plexpy
         rm -f /lib/systemd/system/plexpy.service
         systemctl daemon-reload
+        rm -rf /opt/plexpy
+        deluser --system plexpy
     fi
 fi
 

--- a/var/www/openmediavault/js/omv/module/admin/service/plexmediaserver/Information.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/plexmediaserver/Information.js
@@ -84,7 +84,9 @@ Ext.define("OMV.module.admin.service.plexmediaserver.Information", {
                         '<li>' +
                         'The 1st post contains links to the latest Debian 32 bit and 64 bit package of Plex Media Server.  Download the appropriate package for your machine.' +
                         '</li>' +
-                        '</ol>' 
+                        '</ol>' +
+                        '<h3>PlexPy</h3>' +
+                        'By default, PlexPy runs on port <b>TCP 8181</b>; it can be changed in the application.'
             }]
         }];
     }

--- a/var/www/openmediavault/js/omv/module/admin/service/plexmediaserver/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/plexmediaserver/Settings.js
@@ -188,16 +188,6 @@ Ext.define("OMV.module.admin.service.plexmediaserver.Settings", {
                 name       : "pyrun",
                 fieldLabel : _("Run"),
                 checked    : false
-            }, {
-                xtype: "numberfield",
-                name: "pyport",
-                fieldLabel: _("Port"),
-                vtype: "port",
-                minValue: 1024,
-                maxValue: 65535,
-                allowDecimals: false,
-                allowBlank: true,
-                value: 8182
             }]
         }];
     },

--- a/var/www/openmediavault/js/omv/module/admin/service/plexmediaserver/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/plexmediaserver/Settings.js
@@ -61,7 +61,6 @@ Ext.define("OMV.module.admin.service.plexmediaserver.Settings", {
         },{
             name       : [
                 "pyrun",
-                "pyport",
             ],
             conditions : [
                 { name  : "pyenable", value : true }


### PR DESCRIPTION
Follow https://github.com/JonnyWong16/plexpy/wiki/Install-as-a-daemon instructions:
- create `plexpy` user when enabling
- remove the unused `/etc/default/plexpy` file (the systemd unit doesn't use it)
- the port can be modified in the application, so let the application handle it
- delete the user when disabled

Also:
- migrate the plexpy folder ownership to the new user
- remove the `pyport` setting everywhere
- document the default PlexPy port

Please note that this hasn't been tested.